### PR TITLE
Added support for async / await usage in circuit breaker with async. 

### DIFF
--- a/ReliabilityPatterns/ReliabilityPatterns.csproj
+++ b/ReliabilityPatterns/ReliabilityPatterns.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ReliabilityPatterns</RootNamespace>
     <AssemblyName>ReliabilityPatterns</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Tests</RootNamespace>
     <AssemblyName>Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <repositories>
+  <repository path="../Tests/packages.config" />
   <repository path="..\Tests\packages.config" />
 </repositories>


### PR DESCRIPTION
## The motivation

The simple Circuit Breaker implementation was just what I was looking for one project I have. However I want to protect some nice async methods that do some IO and / or consume by another systems. 
## What

Added support for async / await style execute in circuit breaker.
Added ExecuteAsync<Func> similar to Execute(Func) and their Execute(Action) ExecuteAsync(Action) counterparts.
## How

Needed to do a simple refactor to cope with keeping async / sync versions and comply with the best practice as recommended by http://blogs.msdn.com/b/pfxteam/archive/2012/03/24/10287244.aspx.

Cloned the test scenarios to a "Async" version and added a new test for the case when multiple executions of a failing operation arrive at the same time and go through eventually exceeding the threshold and that works exactly as expected.

Requires upgrade target to c# 4.5+.
