### PR TITLE
Fixing what looks to be a small bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+Thumbs.db
+*.obj
+*.exe
+*.pdb
+*.user
+*.ncb
+*.suo
+[Bb]in
+[Dd]ebug*/
+[Rr]elease*/
+_ReSharper*/
+[Tt]est[Rr]esult*
+*.csproj.user
+*.orig
+[Bb]in/
+[Oo]bj/
+[Oo]utput/

--- a/.hgignore
+++ b/.hgignore
@@ -1,6 +1,0 @@
-bin
-obj
-_ReSharper*
-.suo
-.user
-ReliabilityPatterns.*.nupkg

--- a/ReliabilityPatterns/CircuitBreaker.cs
+++ b/ReliabilityPatterns/CircuitBreaker.cs
@@ -98,6 +98,13 @@ namespace ReliabilityPatterns
                     Interlocked.Increment(ref failureCount);
 
                     OnServiceLevelChanged(new EventArgs());
+
+                    //Re-evalutate the failure count to determine if the breaker should be tripped
+                    if (failureCount >= threshold)
+                    {
+                        // Failure count has reached threshold, so trip circuit breaker
+                        Trip();
+                    }
                 }
                 else if (failureCount >= threshold)
                 {

--- a/Tests/CircuitBreakerTestHelper.cs
+++ b/Tests/CircuitBreakerTestHelper.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using ReliabilityPatterns;
+
+namespace Tests
+{
+    public class CircuitBreakerTestHelper
+    {
+        readonly ushort _allowedRetries;
+        public CircuitBreaker Breaker { get; private set; }
+        public int CallCount { get; private set; }
+
+        public CircuitBreakerTestHelper(uint threshold = 4, ushort allowedRetries = 0)
+        {
+            _allowedRetries = allowedRetries;
+            Breaker = new CircuitBreaker(threshold, TimeSpan.FromSeconds(120));
+        }
+
+        public void ExecuteFailingAction()
+        {
+            Console.WriteLine("Before: " + Breaker.State);
+            try
+            {
+                CallCount = 0;
+                if (_allowedRetries > 0)
+                {
+                    Breaker.ExecuteWithRetries(() =>
+                    {
+                        CallCount++;
+                        throw new Exception("foo");
+                    }, new RetryOptions
+                    {
+                        AllowedRetries = _allowedRetries,
+                        RetryInterval = TimeSpan.FromMilliseconds(10)
+                    });
+                }
+                else
+                {
+                    Breaker.Execute(() =>
+                    {
+                        CallCount++;
+                        throw new Exception("foo");
+                    });
+                }
+            }
+            catch (OpenCircuitException)
+            {
+                Console.WriteLine("Tripped due to open circuit");
+            }
+            catch (OperationFailedException)
+            {
+                Console.WriteLine("Tripped due to unhandled exception");
+            }
+            catch (AggregateException ex)
+            {
+                Console.WriteLine("Tripped due to unhandled exception. InnerExceptionCount: " + ex.InnerExceptions.Count);
+            }
+
+            Console.WriteLine("After {0} attempt/s: {1}", CallCount, Breaker.State + Environment.NewLine);
+        }
+    }
+}

--- a/Tests/CircuitBreakerTests.cs
+++ b/Tests/CircuitBreakerTests.cs
@@ -60,5 +60,27 @@ namespace Tests
 
             return circuitBreaker.ServiceLevel;
         }
+
+        [Test]
+        public void Execute_WhenThresholdIsSetTo4AndCalledWith4FailingActions_ShouldInvokeEachActionOnceAndTheCircuitBreakerShouldFinishOpen()
+        {
+            var testHelper = new CircuitBreakerTestHelper(4);
+
+            testHelper.ExecuteFailingAction();
+            Assert.AreEqual(1, testHelper.CallCount);
+            Assert.AreEqual(CircuitBreakerState.Closed, testHelper.Breaker.State);
+
+            testHelper.ExecuteFailingAction();
+            Assert.AreEqual(1, testHelper.CallCount);
+            Assert.AreEqual(CircuitBreakerState.Closed, testHelper.Breaker.State);
+
+            testHelper.ExecuteFailingAction();
+            Assert.AreEqual(1, testHelper.CallCount);
+            Assert.AreEqual(CircuitBreakerState.Closed, testHelper.Breaker.State);
+
+            testHelper.ExecuteFailingAction();
+            Assert.AreEqual(1, testHelper.CallCount);
+            Assert.AreEqual(CircuitBreakerState.Open, testHelper.Breaker.State);
+        }
     }
 }

--- a/Tests/RetryExtensionsTests.cs
+++ b/Tests/RetryExtensionsTests.cs
@@ -130,5 +130,19 @@ namespace Tests
             }
             Assert.IsFalse(actionWasCalled);
         }
+
+        [Test]
+        public void ExecuteWithRetries_WhenThresholdIsSetTo4AndAllowedRetriesIsSetTo3AndCalledWith2FailingActions_InvokesTheFirstAction3TimesAndInvokesTheSecondAction1TimeAndTheCircuitBreakerShouldFinishOpen()
+        {
+            var testHelper = new CircuitBreakerTestHelper(4, 3);
+
+            testHelper.ExecuteFailingAction();
+            Assert.AreEqual(3, testHelper.CallCount);
+            Assert.AreEqual(CircuitBreakerState.Closed, testHelper.Breaker.State);
+
+            testHelper.ExecuteFailingAction();
+            Assert.AreEqual(1, testHelper.CallCount);
+            Assert.AreEqual(CircuitBreakerState.Open, testHelper.Breaker.State);
+        }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CircuitBreakerTestHelper.cs" />
     <Compile Include="CircuitBreakerTests.cs" />
     <Compile Include="ReliableParallelForEachTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
The operation passed into Execute/ExecuteWithRetries seems to be invoked 1 additional time than the configured circuit breaker threshold before going into the open circuit state. I don't think this is the desired behavior.

This PR should fix it.
The tests will also log some info to the console to help give context.
